### PR TITLE
Show graphs on mismatch in tests

### DIFF
--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -50,3 +50,12 @@ def test_graph_builder_rebuilds_pt(pt_path):
 
     assert len(list(rebuilt.parameters())) == len(expected_edges)
     assert len(rebuilt.node_types) == len(data.node_types)
+
+    # Verify that the rebuilt computation graph is identical to the original
+    if str(rebuilt.graph) != str(original.graph):
+        print("Original graph:\n", original.graph)
+        print("Rebuilt graph:\n", rebuilt.graph)
+    assert str(rebuilt.graph) == str(original.graph), (
+        "\nOriginal graph:\n" + str(original.graph) +
+        "\nRebuilt graph:\n" + str(rebuilt.graph)
+    )


### PR DESCRIPTION
## Summary
- print both graphs when equality check fails in `test_graph_builder_rebuilds_pt`

## Testing
- `pytest -q` *(fails: graph comparison assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887e72c14e883339fc736406f12705e